### PR TITLE
Fixed issue with including files in directory with trailing slash

### DIFF
--- a/Unix/cloc
+++ b/Unix/cloc
@@ -8829,6 +8829,10 @@ sub normalize_file_names {                   # {{{1
                 $F_norm = lc "$cwd/$F_norm";
             }
         }
+        # Remove trailing / so it does not interfere with further regex code 
+        # that does not expect it
+        $F_norm =~ s{/$}{}g;
+
         $normalized{ $F_norm } = $F;
     }
     return %normalized;


### PR DESCRIPTION
Step to reproduce:
- Add to --exclude-list-file=file_list.txt directory with trailing slash.

Expected:
- Files in directory with trailing slash are ignored.

Actual result:
-  Files in directory with trailing slash are not ignored.
